### PR TITLE
fix misleading indentation causing compulation failure

### DIFF
--- a/storage/index_btree.cpp
+++ b/storage/index_btree.cpp
@@ -380,24 +380,24 @@ RC index_btree::find_leaf(glob_param params, idx_key_t key, idx_acc_t access_typ
 
 RC index_btree::insert_into_leaf(glob_param params, bt_node * leaf, idx_key_t key, itemid_t * item) {
 	UInt32 i, insertion_point;
-    insertion_point = 0;
+	insertion_point = 0;
 	int idx = leaf_has_key(leaf, key);	
 	if (idx >= 0) {
 		item->next = (itemid_t *)leaf->pointers[idx];
 		leaf->pointers[idx] = (void *) item;
 		return RCOK;
 	}
-    while (insertion_point < leaf->num_keys && leaf->keys[insertion_point] < key)
-        insertion_point++;
+	while (insertion_point < leaf->num_keys && leaf->keys[insertion_point] < key)
+		insertion_point++;
 	for (i = leaf->num_keys; i > insertion_point; i--) {
-        leaf->keys[i] = leaf->keys[i - 1];
-        leaf->pointers[i] = leaf->pointers[i - 1];
-    }
-    leaf->keys[insertion_point] = key;
-    leaf->pointers[insertion_point] = (void *)item;
-    leaf->num_keys++;
+		leaf->keys[i] = leaf->keys[i - 1];
+		leaf->pointers[i] = leaf->pointers[i - 1];
+	}
+	leaf->keys[insertion_point] = key;
+	leaf->pointers[insertion_point] = (void *)item;
+	leaf->num_keys++;
 	M_ASSERT( (leaf->num_keys < order), "too many keys in leaf" );
-    return RCOK;
+	return RCOK;
 }
 
 RC index_btree::split_lf_insert(glob_param params, bt_node * leaf, idx_key_t key, itemid_t * item) {
@@ -486,10 +486,10 @@ RC index_btree::insert_into_parent(
     if (parent == NULL)
         return insert_into_new_root(params, left, key, right);
     
-	UInt32 insert_idx = 0;
-	while (parent->keys[insert_idx] < key && insert_idx < parent->num_keys)
-		insert_idx ++;
-	// the parent has enough space, just insert into it
+    UInt32 insert_idx = 0;
+    while (parent->keys[insert_idx] < key && insert_idx < parent->num_keys)
+        insert_idx ++;
+    // the parent has enough space, just insert into it
     if (parent->num_keys < order - 1) {
 		for (UInt32 i = parent->num_keys-1; i >= insert_idx; i--) {
 			parent->keys[i + 1] = parent->keys[i];
@@ -499,13 +499,13 @@ RC index_btree::insert_into_parent(
 		parent->keys[insert_idx] = key;
 		parent->pointers[insert_idx + 1] = right;
 		return RCOK;
-	}
+     }
 
     /* Harder case:  split a node in order 
      * to preserve the B+ tree properties.
      */
 	
-	return split_nl_insert(params, parent, insert_idx, key, right);
+     return split_nl_insert(params, parent, insert_idx, key, right);
 //	return RCOK;
 }
 

--- a/system/manager.cpp
+++ b/system/manager.cpp
@@ -66,9 +66,9 @@ ts_t Manager::get_min_ts(uint64_t tid) {
 	if (tid == 0 && now - last_time > MIN_TS_INTVL)
 	{ 
 		ts_t min = UINT64_MAX;
-    	for (UInt32 i = 0; i < g_thread_cnt; i++) 
-	    	if (*all_ts[i] < min)
-    	    	min = *all_ts[i];
+		for (UInt32 i = 0; i < g_thread_cnt; i++)
+			if (*all_ts[i] < min)
+				min = *all_ts[i];
 		if (min > _min_ts)
 			_min_ts = min;
 	}


### PR DESCRIPTION
gcc-7.3.1

errors like:

storage/index_btree.cpp: In member function ‘RC index_btree::insert_into_leaf(glob_param, bt_node*, idx_key_t, itemid_t*)’:
storage/index_btree.cpp:390:5: error: this ‘while’ clause does not guard... [-Werror=misleading-indentation]
     while (insertion_point < leaf->num_keys && leaf->keys[insertion_point] < key)
     ^~~~~
storage/index_btree.cpp:392:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘while’
  for (i = leaf->num_keys; i > insertion_point; i--) {
  ^~~
storage/index_btree.cpp: In member function ‘RC index_btree::insert_into_parent(glob_param, bt_node*, idx_key_t, bt_node*)’:
storage/index_btree.cpp:486:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if (parent == NULL)
     ^~
storage/index_btree.cpp:489:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  UInt32 insert_idx = 0;
  ^~~~~~